### PR TITLE
Add script to generate interactive story notebook

### DIFF
--- a/generate_notebook.py
+++ b/generate_notebook.py
@@ -1,0 +1,114 @@
+import os
+import argparse
+from difflib import SequenceMatcher
+from itertools import cycle
+import nbformat
+from nbformat.v4 import new_notebook, new_markdown_cell, new_code_cell
+import subprocess
+
+def collect_blocks(root, limit=None):
+    """Traverse directory and collect text blocks, removing duplicates and similar blocks."""
+    blocks = []
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            if name.lower().endswith((".md", ".txt", ".py")):
+                path = os.path.join(dirpath, name)
+                try:
+                    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                        content = f.read()
+                except Exception:
+                    continue
+                paragraphs = [p.strip() for p in content.split("\n\n") if p.strip()]
+                blocks.extend(paragraphs)
+                if limit and len(blocks) >= limit:
+                    blocks = blocks[:limit]
+                    break
+        if limit and len(blocks) >= limit:
+            break
+    return simplify_blocks(blocks)
+
+def simplify_blocks(blocks, threshold=0.9):
+    """Remove duplicate or highly similar blocks."""
+    unique = []
+    for block in blocks:
+        if not any(SequenceMatcher(None, block, u).ratio() >= threshold for u in unique):
+            unique.append(block)
+    return unique
+
+def create_story(blocks):
+    characters = ["Alice", "Bob", "Charlie", "Dana"]
+    images = [f"https://placehold.co/600x400?text=Image+{i}" for i in range(len(blocks))]
+    audios = [f"https://example.com/audio{i}.mp3" for i in range(len(blocks))]
+    story = []
+    char_cycle = cycle(characters)
+    for i, block in enumerate(blocks):
+        story.append(
+            {
+                "character": next(char_cycle),
+                "text": block,
+                "image": images[i],
+                "audio": audios[i],
+            }
+        )
+    return story
+
+def build_notebook(story, out_path):
+    nb = new_notebook()
+    nb.cells.append(new_markdown_cell("# Interactive Story"))
+    nb.cells.append(new_code_cell("story = {}".format(repr(story))))
+    navigation_code = """
+import ipywidgets as widgets
+from IPython.display import display, Markdown
+index = 0
+out = widgets.Output()
+
+def show(i):
+    block = story[i]
+    md = f"### {block['character']}\\n![]({block['image']})\\n[Audio]({block['audio']})\\n\\n{block['text']}"
+    with out:
+        out.clear_output()
+        display(Markdown(md))
+
+show(index)
+
+def next_block(_):
+    global index
+    if index < len(story) - 1:
+        index += 1
+        show(index)
+
+def prev_block(_):
+    global index
+    if index > 0:
+        index -= 1
+        show(index)
+
+next_btn = widgets.Button(description='Next')
+prev_btn = widgets.Button(description='Previous')
+next_btn.on_click(next_block)
+prev_btn.on_click(prev_block)
+display(widgets.HBox([prev_btn, next_btn]), out)
+"""
+    nb.cells.append(new_code_cell(navigation_code))
+    with open(out_path, "w", encoding="utf-8") as f:
+        nbformat.write(nb, f)
+
+def export_notebook(nb_path, fmt):
+    subprocess.run(["jupyter", "nbconvert", "--to", fmt, nb_path], check=True)
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate interactive story notebook")
+    parser.add_argument("root", nargs="?", default=".")
+    parser.add_argument("--limit", type=int, default=None, help="Limit number of blocks")
+    parser.add_argument("--export", choices=["html", "pdf"], help="Export notebook format")
+    args = parser.parse_args()
+
+    blocks = collect_blocks(args.root, limit=args.limit)
+    story = create_story(blocks)
+    nb_path = "interactive_story.ipynb"
+    build_notebook(story, nb_path)
+    if args.export:
+        export_notebook(nb_path, args.export)
+
+if __name__ == "__main__":
+    main()

--- a/interactive_story.ipynb
+++ b/interactive_story.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fddd22fe",
+   "metadata": {},
+   "source": [
+    "# Interactive Story"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99c8bf09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "story = [{'character': 'Alice', 'text': 'import os\\nimport argparse\\nfrom difflib import SequenceMatcher\\nfrom itertools import cycle\\nimport nbformat\\nfrom nbformat.v4 import new_notebook, new_markdown_cell, new_code_cell\\nimport subprocess', 'image': 'https://placehold.co/600x400?text=Image+0', 'audio': 'https://example.com/audio0.mp3'}, {'character': 'Bob', 'text': 'def collect_blocks(root, limit=None):\\n    \"\"\"Traverse directory and collect text blocks, removing duplicates and similar blocks.\"\"\"\\n    blocks = []\\n    for dirpath, _, filenames in os.walk(root):\\n        for name in filenames:\\n            if name.lower().endswith((\".md\", \".txt\", \".py\")):\\n                path = os.path.join(dirpath, name)\\n                try:\\n                    with open(path, \"r\", encoding=\"utf-8\", errors=\"ignore\") as f:\\n                        content = f.read()\\n                except Exception:\\n                    continue\\n                paragraphs = [p.strip() for p in content.split(\"\\\\n\\\\n\") if p.strip()]\\n                blocks.extend(paragraphs)\\n                if limit and len(blocks) >= limit:\\n                    blocks = blocks[:limit]\\n                    break\\n        if limit and len(blocks) >= limit:\\n            break\\n    return simplify_blocks(blocks)', 'image': 'https://placehold.co/600x400?text=Image+1', 'audio': 'https://example.com/audio1.mp3'}, {'character': 'Charlie', 'text': 'def simplify_blocks(blocks, threshold=0.9):\\n    \"\"\"Remove duplicate or highly similar blocks.\"\"\"\\n    unique = []\\n    for block in blocks:\\n        if not any(SequenceMatcher(None, block, u).ratio() >= threshold for u in unique):\\n            unique.append(block)\\n    return unique', 'image': 'https://placehold.co/600x400?text=Image+2', 'audio': 'https://example.com/audio2.mp3'}, {'character': 'Dana', 'text': 'def create_story(blocks):\\n    characters = [\"Alice\", \"Bob\", \"Charlie\", \"Dana\"]\\n    images = [f\"https://placehold.co/600x400?text=Image+{i}\" for i in range(len(blocks))]\\n    audios = [f\"https://example.com/audio{i}.mp3\" for i in range(len(blocks))]\\n    story = []\\n    char_cycle = cycle(characters)\\n    for i, block in enumerate(blocks):\\n        story.append(\\n            {\\n                \"character\": next(char_cycle),\\n                \"text\": block,\\n                \"image\": images[i],\\n                \"audio\": audios[i],\\n            }\\n        )\\n    return story', 'image': 'https://placehold.co/600x400?text=Image+3', 'audio': 'https://example.com/audio3.mp3'}, {'character': 'Alice', 'text': 'def build_notebook(story, out_path):\\n    nb = new_notebook()\\n    nb.cells.append(new_markdown_cell(\"# Interactive Story\"))\\n    nb.cells.append(new_code_cell(\"story = {}\".format(repr(story))))\\n    navigation_code = \"\"\"\\nimport ipywidgets as widgets\\nfrom IPython.display import display, Markdown\\nindex = 0\\nout = widgets.Output()', 'image': 'https://placehold.co/600x400?text=Image+4', 'audio': 'https://example.com/audio4.mp3'}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "442b7822",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display, Markdown\n",
+    "index = 0\n",
+    "out = widgets.Output()\n",
+    "\n",
+    "def show(i):\n",
+    "    block = story[i]\n",
+    "    md = f\"### {block['character']}\\n![]({block['image']})\\n[Audio]({block['audio']})\\n\\n{block['text']}\"\n",
+    "    with out:\n",
+    "        out.clear_output()\n",
+    "        display(Markdown(md))\n",
+    "\n",
+    "show(index)\n",
+    "\n",
+    "def next_block(_):\n",
+    "    global index\n",
+    "    if index < len(story) - 1:\n",
+    "        index += 1\n",
+    "        show(index)\n",
+    "\n",
+    "def prev_block(_):\n",
+    "    global index\n",
+    "    if index > 0:\n",
+    "        index -= 1\n",
+    "        show(index)\n",
+    "\n",
+    "next_btn = widgets.Button(description='Next')\n",
+    "prev_btn = widgets.Button(description='Previous')\n",
+    "next_btn.on_click(next_block)\n",
+    "prev_btn.on_click(prev_block)\n",
+    "display(widgets.HBox([prev_btn, next_btn]), out)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `generate_notebook.py` to scan repo, deduplicate similar text blocks, and assemble character-based story
- create sample `interactive_story.ipynb` with navigation buttons, image and audio placeholders
- support exporting the notebook to HTML or PDF via nbconvert

## Testing
- `python generate_notebook.py --limit 5 --export html`


------
https://chatgpt.com/codex/tasks/task_e_68a5af191f44832d9bc218207901bdf2